### PR TITLE
exptime is not capped at 2592000 (30 days).  if the value is <2592000, m...

### DIFF
--- a/lib/memcache-client.js
+++ b/lib/memcache-client.js
@@ -198,11 +198,9 @@ Client.prototype.store = function (operation, key, val, opts, cb) {
   var cas;
   if (!cb) { cb = opts; }
   else {
-    if (opts.exptime && opts.exptime > 2592000) {
-      cb({ type: 'INVALID_EXPIRATION_TIME', description: 'Value ' + opts.exptime + ' exceeds max of 2592000'} );
-      return;
+    if (opts.exptime) {
+        exptime = opts.exptime || this.ttl;
     }
-    exptime = opts.exptime || (this.ttl ? Math.floor((new Date()).getTime() / 1000) + this.ttl : 0);
     flags = opts.flags || 0;
     cas = opts.cas;
   }


### PR DESCRIPTION
...emcache interprets the value as an offset in seconds from the current time, otherwise it's treated as unixtime.

I ran into an issue trying to set exptime to a unix timestamp.  I believe this fixes that issue.
